### PR TITLE
feat: add caching for block folder retrieval

### DIFF
--- a/wp-content/themes/refact-starter/inc/acf.php
+++ b/wp-content/themes/refact-starter/inc/acf.php
@@ -42,9 +42,18 @@ add_filter( 'block_categories_all', 'refact_starter_block_categories', 10, 2 );
  * Register ACF Blocks
  */
 function refact_starter_register_acf_blocks() {
-	$acf_blocks = glob( get_template_directory() . '/acf-blocks/*', GLOB_ONLYDIR );
-	foreach ( $acf_blocks as $acf_block ) {
-		register_block_type( $acf_block );
+	// Attempt to retrieve ACF block folders from the cache
+	$acf_block_folders = wp_cache_get( 'acf_block_folders', 'refact_starter' );
+
+	// If ACF block folders are not cached, retrieve them from the file system and cache the result
+	if ( false === $acf_block_folders ) {
+		$acf_block_folders = glob( get_template_directory() . '/acf-blocks/*', GLOB_ONLYDIR );
+		wp_cache_set( 'acf_block_folders', $acf_block_folders, 'refact_starter', WEEK_IN_SECONDS );
+	}
+
+	// Register each ACF block found in the ACF block folders
+	foreach ( $acf_block_folders as $acf_block_folder ) {
+		register_block_type( $acf_block_folder );
 	}
 }
 add_action( 'init', 'refact_starter_register_acf_blocks' );

--- a/wp-content/themes/refact-starter/inc/hooks.php
+++ b/wp-content/themes/refact-starter/inc/hooks.php
@@ -7,12 +7,21 @@
 defined( 'ABSPATH' ) || exit;
 
 /*
-* Register the blocks
+* Register the Blocks
 */
 function refact_starter_register_blocks() {
-	$blocks = glob( get_template_directory() . '/build/blocks/*', GLOB_ONLYDIR );
-	foreach ( $blocks as $block ) {
-		register_block_type( $block );
+	// Attempt to retrieve block folders from the cache
+	$block_folders = wp_cache_get( 'block_folders', 'refact_starter' );
+
+	// If block folders are not cached, retrieve them from the file system and cache the result
+	if ( false === $block_folders ) {
+		$block_folders = glob( get_template_directory() . '/build/blocks/*', GLOB_ONLYDIR );
+		wp_cache_set( 'block_folders', $block_folders, 'refact_starter', WEEK_IN_SECONDS );
+	}
+
+	// Register each block found in the block folders
+	foreach ( $block_folders as $block_folder ) {
+		register_block_type( $block_folder );
 	}
 }
 add_action( 'init', 'refact_starter_register_blocks' );


### PR DESCRIPTION
- Implemented caching with `wp_cache_get` and `wp_cache_set` to optimize block registration.
- Reduced redundant file system access for improved performance.